### PR TITLE
[DX] Maintenance voter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,7 +152,7 @@ jobs:
                       node-${{ matrix.node }}-yarn-
 
             - name: Install Sylius-Standard and Plugin
-              run: make install -e SYLIUS_VERSION=${{ matrix.sylius }} SYMFONY_VERSION=${{ matrix.symfony }}
+              run: make install -e SYLIUS_VERSION=${{ matrix.sylius }} SYMFONY_VERSION=${{ matrix.symfony }} PHP_VERSION=${{ matrix.php }}
 
             - name: Run PHPUnit
               run: make phpunit

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ update-dependencies:
 	${COMPOSER} config extra.symfony.require "^${SYMFONY_VERSION}"
 	${COMPOSER} require --dev donatj/mock-webserver:^2.1 --no-scripts --no-update
 ifeq ($(shell [[ $(SYMFONY_VERSION) == 4.4 && $(PHP_VERSION) == 7.4 ]] && echo true ),true)
-	${COMPOSER} require sylius/admin-api-bundle --no-scripts --no-update
+	${COMPOSER} require sylius/admin-api-bundle:1.10 --no-scripts --no-update
 endif
 ifeq ($(SYLIUS_VERSION), 1.8.0)
 	${COMPOSER} update --no-progress --no-scripts --prefer-dist -n

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ CONSOLE=cd tests/Application && php bin/console
 COMPOSER=cd tests/Application && composer
 YARN=cd tests/Application && yarn
 
-SYLIUS_VERSION=1.11.0
-SYMFONY_VERSION=5.4
-PHP_VERSION=8.0
+SYLIUS_VERSION=1.9.0
+SYMFONY_VERSION=4.4
+PHP_VERSION=7.4
 PLUGIN_NAME=synolia/sylius-maintenance-plugin
 
 ###
@@ -66,7 +66,7 @@ phpunit-configure:
 	cp phpunit.xml.dist ${TEST_DIRECTORY}/phpunit.xml
 
 phpunit-run:
-	cd ${TEST_DIRECTORY} && ./vendor/bin/phpunit
+	cd ${TEST_DIRECTORY} && ./vendor/bin/phpunit --process-isolation --do-not-cache-result
 
 grumphp:
 	vendor/bin/grumphp run

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ CONSOLE=cd tests/Application && php bin/console
 COMPOSER=cd tests/Application && composer
 YARN=cd tests/Application && yarn
 
-SYLIUS_VERSION=1.9.0
-SYMFONY_VERSION=4.4
-PHP_VERSION=7.4
+SYLIUS_VERSION=1.11.0
+SYMFONY_VERSION=5.4
+PHP_VERSION=8.0
 PLUGIN_NAME=synolia/sylius-maintenance-plugin
 
 ###

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -19,7 +19,8 @@ grumphp:
         phpstan:
             level: ~
             configuration: 'ruleset/phpstan.neon'
-        yamllint: ~
+        yamllint:
+            parse_custom_tags: true
         ecs:
             config: 'ruleset/ecs.php'
             no-progress-bar: true

--- a/ruleset/phpstan.neon
+++ b/ruleset/phpstan.neon
@@ -18,3 +18,5 @@ parameters:
     ignoreErrors:
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'
         - '#Call to an undefined method Sylius\\Component\\Channel\\Repository\\ChannelRepositoryInterface::count\(\)\.#'
+        # Error not rightely reported because of Symfony 4.4
+        - "#^Call to function method_exists\\(\\) with Symfony\\\\Component\\\\HttpFoundation\\\\RequestStack and '.*' will always evaluate to true\\.$#"

--- a/src/Checker/AdminChecker.php
+++ b/src/Checker/AdminChecker.php
@@ -63,17 +63,11 @@ class AdminChecker implements IsMaintenanceCheckerInterface
     private function getMainRequest(): ?Request
     {
         if (method_exists($this->requestStack, 'getMainRequest')) {
-            /** @var Request|null $request */
-            $request = $this->requestStack->getMainRequest();
-
-            return $request;
+            return$this->requestStack->getMainRequest();
         }
 
         if (method_exists($this->requestStack, 'getMasterRequest')) {
-            /** @var Request|null $request */
-            $request = $this->requestStack->getMasterRequest();
-
-            return $request;
+            return $this->requestStack->getMasterRequest();
         }
 
         throw new LogicException(sprintf(

--- a/src/Checker/AdminChecker.php
+++ b/src/Checker/AdminChecker.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMaintenancePlugin\Checker;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
+use Synolia\SyliusMaintenancePlugin\Voter\IsMaintenanceVoterInterface;
+
+class AdminChecker implements IsMaintenanceCheckerInterface
+{
+    protected ParameterBagInterface $params;
+
+    protected RequestStack $requestStack;
+
+    protected FlashBagInterface $flashBag;
+
+    protected TranslatorInterface $translator;
+
+    public function __construct(
+        ParameterBagInterface $params,
+        RequestStack $requestStack,
+        FlashBagInterface $flashBag,
+        TranslatorInterface $translator
+    ) {
+        $this->params = $params;
+        $this->requestStack = $requestStack;
+        $this->flashBag = $flashBag;
+        $this->translator = $translator;
+    }
+
+    public static function getDefaultPriority(): int
+    {
+        return 70;
+    }
+
+    public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
+    {
+        $getRequestUri = $request->getRequestUri();
+        /** @var string $adminPrefix */
+        $adminPrefix = $this->params->get('sylius_admin.path_name');
+
+        if (false !== mb_strpos($getRequestUri, $adminPrefix, 1)) {
+            if ($this->requestStack->getMainRequest() === $this->requestStack->getCurrentRequest()) {
+                $this->flashBag->add('info', $this->translator->trans('maintenance.ui.message_info_admin'));
+            }
+
+            return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+        }
+
+        return IsMaintenanceVoterInterface::ACCESS_DENIED;
+    }
+}

--- a/src/Checker/AdminChecker.php
+++ b/src/Checker/AdminChecker.php
@@ -63,7 +63,7 @@ class AdminChecker implements IsMaintenanceCheckerInterface
     private function getMainRequest(): ?Request
     {
         if (method_exists($this->requestStack, 'getMainRequest')) {
-            return$this->requestStack->getMainRequest();
+            return $this->requestStack->getMainRequest();
         }
 
         if (method_exists($this->requestStack, 'getMasterRequest')) {

--- a/src/Checker/ChannelChecker.php
+++ b/src/Checker/ChannelChecker.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMaintenancePlugin\Checker;
+
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
+use Synolia\SyliusMaintenancePlugin\Voter\IsMaintenanceVoterInterface;
+
+class ChannelChecker implements IsMaintenanceCheckerInterface
+{
+    protected ChannelRepositoryInterface $channelRepository;
+
+    protected ChannelContextInterface $channelContext;
+
+    public function __construct(
+        ChannelRepositoryInterface $channelRepository,
+        ChannelContextInterface $channelContext
+    ) {
+        $this->channelRepository = $channelRepository;
+        $this->channelContext = $channelContext;
+    }
+
+    public static function getDefaultPriority(): int
+    {
+        return 60;
+    }
+
+    public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
+    {
+        if ($this->channelRepository->count([]) > 1) {
+            if (!\in_array($this->channelContext->getChannel()->getCode(), $configuration->getChannels(), true)) {
+                return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+            }
+        }
+
+        return IsMaintenanceVoterInterface::ACCESS_DENIED;
+    }
+}

--- a/src/Checker/EnabledChecker.php
+++ b/src/Checker/EnabledChecker.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMaintenancePlugin\Checker;
+
+use Symfony\Component\HttpFoundation\Request;
+use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
+use Synolia\SyliusMaintenancePlugin\Voter\IsMaintenanceVoterInterface;
+
+class EnabledChecker implements IsMaintenanceCheckerInterface
+{
+    public static function getDefaultPriority(): int
+    {
+        return 100;
+    }
+
+    public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
+    {
+        if ($configuration->isEnabled()) {
+            return IsMaintenanceVoterInterface::ACCESS_DENIED;
+        }
+
+        return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+    }
+}

--- a/src/Checker/IpChecker.php
+++ b/src/Checker/IpChecker.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMaintenancePlugin\Checker;
+
+use Symfony\Component\HttpFoundation\Request;
+use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
+use Synolia\SyliusMaintenancePlugin\Voter\IsMaintenanceVoterInterface;
+
+class IpChecker implements IsMaintenanceCheckerInterface
+{
+    public static function getDefaultPriority(): int
+    {
+        return 90;
+    }
+
+    public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
+    {
+        $ipUser = $request->getClientIp();
+        $authorizedIps = $configuration->getArrayIpsAddresses();
+
+        if (in_array($ipUser, $authorizedIps, true)) {
+            return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+        }
+
+        return IsMaintenanceVoterInterface::ACCESS_DENIED;
+    }
+}

--- a/src/Checker/IpChecker.php
+++ b/src/Checker/IpChecker.php
@@ -17,10 +17,9 @@ class IpChecker implements IsMaintenanceCheckerInterface
 
     public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
     {
-        $ipUser = $request->getClientIp();
         $authorizedIps = $configuration->getArrayIpsAddresses();
 
-        if (in_array($ipUser, $authorizedIps, true)) {
+        if (in_array($request->getClientIp(), $authorizedIps, true)) {
             return IsMaintenanceVoterInterface::ACCESS_GRANTED;
         }
 

--- a/src/Checker/IsMaintenanceCheckerInterface.php
+++ b/src/Checker/IsMaintenanceCheckerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMaintenancePlugin\Checker;
+
+use Symfony\Component\HttpFoundation\Request;
+use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
+
+interface IsMaintenanceCheckerInterface
+{
+    public const TAG_ID = 'synolia_maintenance.checker.is_maintenance';
+
+    public static function getDefaultPriority(): int;
+
+    public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool;
+}

--- a/src/Checker/ScheduledChecker.php
+++ b/src/Checker/ScheduledChecker.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMaintenancePlugin\Checker;
+
+use Symfony\Component\HttpFoundation\Request;
+use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
+use Synolia\SyliusMaintenancePlugin\Voter\IsMaintenanceVoterInterface;
+
+class ScheduledChecker implements IsMaintenanceCheckerInterface
+{
+    public static function getDefaultPriority(): int
+    {
+        return 80;
+    }
+
+    public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
+    {
+        if (false === $this->isActuallyScheduledMaintenance($configuration) &&
+            (null !== $configuration->getStartDate() ||
+                null !== $configuration->getEndDate())
+        ) {
+            return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+        }
+
+        return IsMaintenanceVoterInterface::ACCESS_DENIED;
+    }
+
+    private function isActuallyScheduledMaintenance(MaintenanceConfiguration $maintenanceConfiguration): bool
+    {
+        $now = new \DateTime();
+        $startDate = $maintenanceConfiguration->getStartDate();
+        $endDate = $maintenanceConfiguration->getEndDate();
+        // Now is between startDate and endDate
+        if ($startDate !== null && $endDate !== null && ($now >= $startDate) && ($now <= $endDate)) {
+            return true;
+        }
+        // No enddate provided, now is greater than startDate
+        if ($startDate !== null && $endDate === null && ($now >= $startDate)) {
+            return true;
+        }
+        // No startdate provided, now is before than enddate
+        if ($endDate !== null && $startDate === null && ($now <= $endDate)) {
+            return true;
+        }
+        // No schedule date
+        return false;
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -10,6 +10,11 @@ services:
     bind:
       $maintenanceDirectory: '%synolia_maintenance_dir%'
 
+  _instanceof:
+    Synolia\SyliusMaintenancePlugin\Checker\IsMaintenanceCheckerInterface:
+      tags:
+        - { name: !php/const Synolia\SyliusMaintenancePlugin\Checker\IsMaintenanceCheckerInterface::TAG_ID }
+
   Synolia\SyliusMaintenancePlugin\:
     resource: '../../*'
     exclude: '../../{Controller,Migrations,SynoliaSyliusMaintenancePlugin.php}'
@@ -22,3 +27,7 @@ services:
     tags:
       - { name: kernel.event_listener, event: sylius.menu.admin.main, method: addAdminMenuItems }
 
+  Synolia\SyliusMaintenancePlugin\Voter\IsMaintenanceVoterInterface:
+    class: Synolia\SyliusMaintenancePlugin\Voter\IsMaintenanceVoter
+    arguments:
+      - !tagged_iterator { tag: !php/const Synolia\SyliusMaintenancePlugin\Checker\IsMaintenanceCheckerInterface::TAG_ID }

--- a/src/Voter/IsMaintenanceVoter.php
+++ b/src/Voter/IsMaintenanceVoter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMaintenancePlugin\Voter;
+
+use Symfony\Component\HttpFoundation\Request;
+use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
+
+class IsMaintenanceVoter implements IsMaintenanceVoterInterface
+{
+    /** @var array<\Synolia\SyliusMaintenancePlugin\Checker\IsMaintenanceCheckerInterface> */
+    private $isMaintenanceCheckers;
+
+    public function __construct(\Traversable $checkers)
+    {
+        $this->isMaintenanceCheckers = iterator_to_array($checkers);
+    }
+
+    public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
+    {
+        foreach ($this->isMaintenanceCheckers as $checker) {
+            $result = $checker->isMaintenance($configuration, $request);
+
+            // As soon as a voter says that the site is accessible then we deactivate the maintenance
+            if (IsMaintenanceVoterInterface::ACCESS_GRANTED === $result) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Voter/IsMaintenanceVoterInterface.php
+++ b/src/Voter/IsMaintenanceVoterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMaintenancePlugin\Voter;
+
+use Symfony\Component\HttpFoundation\Request;
+use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
+
+interface IsMaintenanceVoterInterface
+{
+    public const ACCESS_GRANTED = true;
+
+    public const ACCESS_DENIED = false;
+
+    public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool;
+}

--- a/tests/PHPUnit/AbstractWebTestCase.php
+++ b/tests/PHPUnit/AbstractWebTestCase.php
@@ -29,7 +29,6 @@ abstract class AbstractWebTestCase extends WebTestCase
 
         if (!self::$client) {
             self::$client = self::createClient();
-            self::$client->followRedirects();
         }
 
         $this->manager = self::$container->get('doctrine')->getManager();

--- a/tests/PHPUnit/MaintenanceByChannelTest.php
+++ b/tests/PHPUnit/MaintenanceByChannelTest.php
@@ -55,10 +55,10 @@ final class MaintenanceByChannelTest extends AbstractWebTestCase
             ])
         );
 
-        self::$client->request('GET', 'http://fashion.localhost');
+        self::$client->request('GET', 'http://fashion.localhost/en_US/');
         $this->assertSiteIsUp();
 
-        self::$client->request('GET', 'http://maintenance.localhost');
+        self::$client->request('GET', 'http://maintenance.localhost/en_US/');
         $this->assertSiteIsInMaintenance();
     }
 }

--- a/tests/PHPUnit/MaintenanceByFileTest.php
+++ b/tests/PHPUnit/MaintenanceByFileTest.php
@@ -11,7 +11,7 @@ final class MaintenanceByFileTest extends AbstractWebTestCase
     public function testMaintenanceEnabledWhenFileExist(): void
     {
         \touch($this->file);
-        self::$client->request('GET', '/');
+        self::$client->request('GET', '/en_US/');
 
         $this->assertSiteIsInMaintenance();
     }
@@ -19,7 +19,7 @@ final class MaintenanceByFileTest extends AbstractWebTestCase
     public function testMaintenanceNotAffectAdminArea(): void
     {
         \touch($this->file);
-        self::$client->request('GET', '/admin/');
+        self::$client->request('GET', '/admin/login');
 
         self::assertResponseIsSuccessful();
         self::assertPageTitleContains('Sylius | Administration panel login');
@@ -36,7 +36,7 @@ final class MaintenanceByFileTest extends AbstractWebTestCase
             ])
         );
 
-        self::$client->request('GET', '/');
+        self::$client->request('GET', '/en_US/');
 
         if ($maintenance) {
             $this->assertSiteIsInMaintenance();
@@ -55,7 +55,7 @@ final class MaintenanceByFileTest extends AbstractWebTestCase
             ])
         );
 
-        self::$client->request('GET', '/');
+        self::$client->request('GET', '/en_US/');
 
         $this->assertSiteIsInMaintenance($message);
     }
@@ -81,7 +81,7 @@ final class MaintenanceByFileTest extends AbstractWebTestCase
             ])
         );
 
-        self::$client->request('GET', '/');
+        self::$client->request('GET', '/en_US/');
 
         if ($maintenance) {
             $this->assertSiteIsInMaintenance();

--- a/tests/PHPUnit/MaintenanceByFileTest.php
+++ b/tests/PHPUnit/MaintenanceByFileTest.php
@@ -16,6 +16,16 @@ final class MaintenanceByFileTest extends AbstractWebTestCase
         $this->assertSiteIsInMaintenance();
     }
 
+    public function testMaintenanceNotAffectAdminArea(): void
+    {
+        \touch($this->file);
+        self::$client->request('GET', '/admin/');
+
+        self::assertResponseIsSuccessful();
+        self::assertPageTitleContains('Sylius | Administration panel login');
+        self::assertSelectorTextContains('.form', 'Login');
+    }
+
     /** @dataProvider listOfIps */
     public function testMaintenanceFileWithIp(array $ips, bool $maintenance): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?   | no
| Fixed issue | 

Use of a Voter to know if the shop is under maintenance.
Based on https://www.synolia.com/synolab/back-office/patron-chaine-responsabilite/ and Symfony/Security AccessDecisionManager.