### PR TITLE
Use Template without message

### DIFF
--- a/src/EventSubscriber/MaintenanceEventsubscriber.php
+++ b/src/EventSubscriber/MaintenanceEventsubscriber.php
@@ -7,7 +7,6 @@ namespace Synolia\SyliusMaintenancePlugin\EventSubscriber;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Contracts\Translation\TranslatorInterface;
 use Synolia\SyliusMaintenancePlugin\Factory\MaintenanceConfigurationFactory;
 use Synolia\SyliusMaintenancePlugin\Voter\IsMaintenanceVoterInterface;
 use Twig\Environment;
@@ -15,7 +14,6 @@ use Twig\Environment;
 final class MaintenanceEventsubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private TranslatorInterface $translator,
         private Environment $twig,
         private MaintenanceConfigurationFactory $configurationFactory,
         private IsMaintenanceVoterInterface $isMaintenanceVoter,
@@ -37,13 +35,9 @@ final class MaintenanceEventsubscriber implements EventSubscriberInterface
             return;
         }
 
-        $responseContent = $this->translator->trans('maintenance.ui.message');
-
-        if ('' !== $configuration->getCustomMessage()) {
-            $responseContent = $this->twig->render('@SynoliaSyliusMaintenancePlugin/maintenance.html.twig', [
-                'custom_message' => $configuration->getCustomMessage(),
-            ]);
-        }
+        $responseContent = $this->twig->render('@SynoliaSyliusMaintenancePlugin/maintenance.html.twig', [
+            'custom_message' => $configuration->getCustomMessage(),
+        ]);
 
         $event->setResponse(new Response($responseContent, Response::HTTP_SERVICE_UNAVAILABLE));
     }

--- a/src/Resources/views/maintenance.html.twig
+++ b/src/Resources/views/maintenance.html.twig
@@ -1,2 +1,2 @@
 
-{{ custom_message|raw }}
+{{ custom_message|default('maintenance.ui.message'|trans)|raw }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?   | no
| Fixed issue |  <!-- #-prefixed issue number(s), if any -->

We can now use template even if we don't want to configure message in BO.
