### PR TITLE
fix: keep maintenance file alive when maintenance mode is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@
       php bin/console maintenance:disable
       ```
 
+  4. Remove configuration file using CLI
+
+  By default, **maintenance.yaml** configuration file remains when running `maintenance:disable` or via admin panel using toggle disable
+  Nevertheless passing option `[-c|--clear]` to command line above will reset previous saved configuration
+
 ### You can also turn your website under maintenance in Back Office :     
 
 - Enable/disable the plugin

--- a/src/Exporter/MaintenanceConfigurationExporter.php
+++ b/src/Exporter/MaintenanceConfigurationExporter.php
@@ -15,10 +15,6 @@ final class MaintenanceConfigurationExporter
 
     public function export(MaintenanceConfiguration $configuration): void
     {
-        $this->configurationFileManager->deleteMaintenanceFile();
-        if (!$configuration->isEnabled()) {
-            return;
-        }
         $dataToExport = [];
 
         $ipAddresses = $configuration->getArrayIpsAddresses();
@@ -40,6 +36,7 @@ final class MaintenanceConfigurationExporter
         if ($configuration->allowBots()) {
             $dataToExport['allow_bots'] = true;
         }
+        $dataToExport['enabled'] = $configuration->isEnabled();
         $scheduler = $this->getSchedulerArray($configuration->getStartDate(), $configuration->getEndDate());
 
         $this->configurationFileManager->createMaintenanceFile(array_merge(

--- a/src/Factory/MaintenanceConfigurationFactory.php
+++ b/src/Factory/MaintenanceConfigurationFactory.php
@@ -46,6 +46,7 @@ final class MaintenanceConfigurationFactory
             'custom_message' => '',
             'token' => '',
             'allow_bots' => false,
+            'enabled' => true,
         ]);
         $options = $resolver->resolve($options);
 
@@ -67,6 +68,7 @@ final class MaintenanceConfigurationFactory
             ->setCustomMessage($options['custom_message'])
             ->setToken($options['token'])
             ->setAllowBots($options['allow_bots'])
+            ->setEnabled($options['enabled'])
         ;
     }
 }

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -18,6 +18,7 @@ maintenance:
             allow_bots: Grant access to search bots during maintenance
         message_enabled: The maintenance plugin was successfully enabled.
         message_disabled: The maintenance plugin was successfully disabled.
+        message_reset: The maintenance plugin was successfully reset.
         message_success_ips: The ips were added to the file maintenance.yaml successfully.
         message_error_ips: An error occurred while adding ips addresses. Add one or multiple ips addresses separated with a comma.
         message_disabled_404: The plugin is disabled.

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -18,6 +18,7 @@ maintenance:
             allow_bots: Accorder l'accès aux robots de recherche pendant la maintenance
         message_enabled: Le plugin de maintenance a été activé avec succès.
         message_disabled: Le plugin de maintenance a été désactivé avec succès.
+        message_reset: Le plugin de maintenance a été réinitialisé avec succès.
         message_success_ips: Les adresses ip ont été ajoutés au fichier maintenance.yaml avec succès.
         message_error_ips: Une erreur s'est produite lors de l'ajout d'adresses ip. Ajouter une ou plusieurs adresses ip séparées par une virgule.
         message_disabled_404: Le plugin est désactivé.

--- a/tests/PHPUnit/MaintenanceNotEnabledTest.php
+++ b/tests/PHPUnit/MaintenanceNotEnabledTest.php
@@ -4,10 +4,24 @@ declare(strict_types=1);
 
 namespace Tests\Synolia\SyliusMaintenancePlugin\PHPUnit;
 
+use Symfony\Component\Yaml\Yaml;
+
 final class MaintenanceNotEnabledTest extends AbstractWebTestCase
 {
-    public function testMaintenanceIsNotEnabled(): void
+    public function testMaintenanceIsNotEnabledWhenFileDoesNotExist(): void
     {
+        self::$client->request('GET', '/en_US/');
+        $this->assertSiteIsUp();
+    }
+
+    public function testMaintenanceIsNotEnabledWhenFileIsNotEnabled(): void
+    {
+        \file_put_contents(
+            $this->file,
+            Yaml::dump([
+                'enabled' => false,
+            ]),
+        );
         self::$client->request('GET', '/en_US/');
         $this->assertSiteIsUp();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed issue | #35 

removing maintenance file is still possible but now optional just run `bin/console maintenance:disable [-c|--clear]`
