### PR TITLE
add allow-admins, improve token checker and response

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@
 
 - Enable/disable the plugin
 - Allow access for one or multiple ips addresses (optional)
-- Allow access for secret token (optional)
+- Allow access for secret token (session and request) (optional)
 - Create your custom message (optional)
 - Grant access to search bots during maintenance (optional)
+- Grant access to admins during maintenance (optional)
 
 ### If you want to put the **maintenance.yaml** in a directory, please add your directory in .env:
 For example :

--- a/src/Checker/AdminChecker.php
+++ b/src/Checker/AdminChecker.php
@@ -45,14 +45,16 @@ class AdminChecker implements IsMaintenanceCheckerInterface
             }
             Assert::isInstanceOf($request, Request::class);
 
-            if ($request === $this->requestStack->getCurrentRequest()) {
-                $flashBag = $request->getSession()->getBag('flashes');
-                if ($flashBag instanceof FlashBagInterface) {
-                    $flashBag->add('info', $this->translator->trans('maintenance.ui.message_info_admin'));
+            if ($configuration->isAllowAdmins()) {
+                if ($request === $this->requestStack->getCurrentRequest()) {
+                    $flashBag = $request->getSession()->getBag('flashes');
+                    if ($flashBag instanceof FlashBagInterface) {
+                        $flashBag->add('info', $this->translator->trans('maintenance.ui.message_info_admin'));
+                    }
                 }
-            }
 
-            return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+                return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+            }
         }
 
         return IsMaintenanceVoterInterface::ACCESS_DENIED;

--- a/src/Checker/TokenChecker.php
+++ b/src/Checker/TokenChecker.php
@@ -18,7 +18,9 @@ class TokenChecker implements IsMaintenanceCheckerInterface
 
     public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
     {
-        if ($request->getSession()->get(TokenStorage::MAINTENANCE_TOKEN_NAME) === $configuration->getToken()) {
+        if ($request->get('maintenanceToken') === $configuration->getToken()) {
+            return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+        } elseif ($request->getSession()->get(TokenStorage::MAINTENANCE_TOKEN_NAME) === $configuration->getToken()) {
             return IsMaintenanceVoterInterface::ACCESS_GRANTED;
         }
 

--- a/src/Controller/MaintenanceConfigurationController.php
+++ b/src/Controller/MaintenanceConfigurationController.php
@@ -49,6 +49,7 @@ final class MaintenanceConfigurationController extends AbstractController
         }
 
         return $this->render('@SynoliaSyliusMaintenancePlugin/Admin/maintenanceConfiguration.html.twig', [
+            'maintenanceConfiguration' => $maintenanceConfiguration,
             'form' => $form->createView(),
         ]);
     }

--- a/src/EventSubscriber/MaintenanceEventsubscriber.php
+++ b/src/EventSubscriber/MaintenanceEventsubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Synolia\SyliusMaintenancePlugin\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -55,7 +56,17 @@ final class MaintenanceEventsubscriber implements EventSubscriberInterface
             'custom_message' => $configuration->getCustomMessage(),
         ]);
 
-        $event->setResponse(new Response($responseContent, Response::HTTP_SERVICE_UNAVAILABLE));
+        if (!$event->getRequest()->isXmlHttpRequest()) {
+            $event->setResponse(new Response($responseContent, Response::HTTP_SERVICE_UNAVAILABLE));
+
+            return;
+        }
+
+        $response = [
+            'key' => 'maintenance',
+            'message' => $configuration->getCustomMessage(),
+        ];
+        $event->setResponse(new JsonResponse($response, Response::HTTP_SERVICE_UNAVAILABLE));
     }
 
     private function getMaintenanceConfiguration(): MaintenanceConfiguration

--- a/src/Factory/MaintenanceConfigurationFactory.php
+++ b/src/Factory/MaintenanceConfigurationFactory.php
@@ -46,6 +46,7 @@ final class MaintenanceConfigurationFactory
             'custom_message' => '',
             'token' => '',
             'allow_bots' => false,
+            'allow_admins' => false,
             'enabled' => true,
         ]);
         $options = $resolver->resolve($options);
@@ -68,6 +69,7 @@ final class MaintenanceConfigurationFactory
             ->setCustomMessage($options['custom_message'])
             ->setToken($options['token'])
             ->setAllowBots($options['allow_bots'])
+            ->setAllowAdmins($options['allow_admins'])
             ->setEnabled($options['enabled'])
         ;
     }

--- a/src/Form/Type/MaintenanceConfigurationType.php
+++ b/src/Form/Type/MaintenanceConfigurationType.php
@@ -67,6 +67,10 @@ final class MaintenanceConfigurationType extends AbstractType
                 'label' => 'maintenance.ui.form.allow_bots',
                 'required' => true,
             ])
+            ->add('allowAdmins', CheckboxType::class, [
+                'label' => 'maintenance.ui.form.allow_admins',
+                'required' => true,
+            ])
         ;
 
         if ($this->channelRepository->count([]) > 1) {

--- a/src/Model/MaintenanceConfiguration.php
+++ b/src/Model/MaintenanceConfiguration.php
@@ -24,6 +24,8 @@ class MaintenanceConfiguration
 
     private bool $allowBots = false;
 
+    private bool $allowAdmins = false;
+
     public function __construct()
     {
         $this->startDate = null;
@@ -157,6 +159,18 @@ class MaintenanceConfiguration
     public function setAllowBots(bool $allowBots): self
     {
         $this->allowBots = $allowBots;
+
+        return $this;
+    }
+
+    public function isAllowAdmins(): bool
+    {
+        return $this->allowAdmins;
+    }
+
+    public function setAllowAdmins(bool $allowAdmins): self
+    {
+        $this->allowAdmins = $allowAdmins;
 
         return $this;
     }

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,0 +1,33 @@
+maintenance:
+    ui:
+        message: Die Webseite befindet im Wartungsmodus
+        title: Wartungsmodus
+        subtitle: Wartungsmodus verwalten
+        form:
+            enabled: Aktiv?
+            ip: Ip Adressen ignorieren (getrennt mit ,)
+            token_storage:
+                button: Generiere Token
+                help: Zugriff über Token erlauben
+                message: Token wurde generiert
+            placeholder: 'Ip Adressen ignorieren (getrennt mit ,) Zum Beispiel: 255.255.255.255,192.0.0.255'
+            custom_message: Nachricht
+            start_date: Start
+            end_date: Ende
+            error_end_date: End-Datum muss hinter Startdatum liegen
+            allow_bots: Erlaube Bots den Zugriff während dem Wartungsmodus
+            allow_admins: Erlaube Admins den Zugriff während dem Wartungsmodus
+        message_enabled: Wartungsmodus aktiviert
+        message_disabled: Wartungsmodus deaktiviert
+        message_reset: Wartungsmodus zurückgesetzt
+        message_success_ips: Ip Adressen wurden gespeichert
+        message_error_ips: Fehler in den Ip-Adressen
+        message_disabled_404: Das Plugin ist nicht aktiv
+        message_success_message: Nachricht erfolgreich gespeichert
+        message_end_date_in_the_past: End-Datum ist in der Vergangenheit, Wartungsmodus wurde beendet
+        message_info_admin: Die Webseite ist im Wartungsmodus
+sylius_plus:
+    rbac:
+        parent:
+            plugin_synolia_maintenances: Wartungsmodus
+        sylius_admin_maintenance_configuration: Wartungsmodus verwalten

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -16,6 +16,7 @@ maintenance:
             end_date: Ends at
             error_end_date: The end date must be later than the start date.
             allow_bots: Grant access to search bots during maintenance
+            allow_admins: Allow admins access during maintenance mode
         message_enabled: The maintenance plugin was successfully enabled.
         message_disabled: The maintenance plugin was successfully disabled.
         message_reset: The maintenance plugin was successfully reset.

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -16,6 +16,7 @@ maintenance:
             end_date: Se termine le
             error_end_date: La date de fin doit être postérieure à la date de début.
             allow_bots: Accorder l'accès aux robots de recherche pendant la maintenance
+            allow_admins: Autoriser l'accès aux administrateurs pendant le mode de maintenance
         message_enabled: Le plugin de maintenance a été activé avec succès.
         message_disabled: Le plugin de maintenance a été désactivé avec succès.
         message_reset: Le plugin de maintenance a été réinitialisé avec succès.

--- a/src/Resources/views/Admin/maintenanceConfiguration.html.twig
+++ b/src/Resources/views/Admin/maintenanceConfiguration.html.twig
@@ -37,6 +37,9 @@
 			<div class="field">
 				<div style="margin-bottom: 0.5em">{{ 'maintenance.ui.form.token_storage.help'|trans }}</div>
 				<a class="ui secondary button" href="{{ path('sylius_admin_maintenance_token_storage') }}">{{ 'maintenance.ui.form.token_storage.button'|trans }}</a>
+                {% if maintenanceConfiguration.token is defined %}
+                    {{ maintenanceConfiguration.token }}
+                {% endif %}
 			</div>
 		</div>
 		{{ form_row(form.customMessage) }}
@@ -45,6 +48,7 @@
 			{{ form_row(form.endDate) }}
 		</div>
 		{{ form_row(form.allowBots) }}
+		{{ form_row(form.allowAdmins) }}
 		{% include '@SyliusUi/Form/Buttons/_update.html.twig' %}
 		{{ form_end(form) }}
 	</div>


### PR DESCRIPTION
I added some improvements:

- Grant access to admins during maintenance (optional) default false, so whole admin can be disabled
- Allow access by secret token also on request
- added german translations
-  added json response for XMLHttpRequest


