### PR TITLE
Add asCommand-attributes to avoid deprecation-warning

### DIFF
--- a/src/Command/EnableMaintenanceCommand.php
+++ b/src/Command/EnableMaintenanceCommand.php
@@ -6,6 +6,7 @@ namespace Synolia\SyliusMaintenancePlugin\Command;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +18,10 @@ use Synolia\SyliusMaintenancePlugin\Factory\MaintenanceConfigurationFactory;
 use Synolia\SyliusMaintenancePlugin\FileManager\ConfigurationFileManager;
 use Synolia\SyliusMaintenancePlugin\Model\MaintenanceConfiguration;
 
+#[AsCommand(
+    name: 'maintenance:enable',
+    description: 'Turn your website under maintenance.',
+)]
 final class EnableMaintenanceCommand extends Command
 {
     protected static $defaultName = 'maintenance:enable';


### PR DESCRIPTION
Hi,

this should only fix

> User Deprecated: Since symfony/console 6.1: Relying on the static property \"$defaultName\" for setting a command name is deprecated. Add the \"Symfony\\Component\\Console\\Attribute\\AsCommand\" attribute to the \"Synolia\\SyliusMaintenancePlugin\\Command\\EnableMaintenanceCommand\" class instead.

while it should remain backward-compatible.