### PR TITLE
Feature/allow admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,18 @@
     ``` shell
     php bin/console maintenance:enable 172.16.254.1 255.255.255.255 192.0.0.255
     ```
-3. Disable the plugin
+3.Enable the plugin and disable admin access
+
+    ``` shell
+    php bin/console maintenance:enable --disable-admin
+    ```
+4.Disable the plugin
 
     ``` shell
     php bin/console maintenance:disable
     ```
 
-4. Remove configuration file using CLI
+5.Remove configuration file using CLI
 
 By default, **maintenance.yaml** configuration file remains when running `maintenance:disable` or via admin panel using toggle disable
 Nevertheless passing option `[-c|--clear]` to command line above will reset previous saved configuration

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ framework:
                 adapter: cache.adapter.redis
 ```
 
+### Precisions for access token
+
+Once token is generated, disallowing maintenance will be available thought request as well.
+So you can use it as query parameter `?synolia_maintenance_token={$token}` or in headers `HTTP_SYNOLIA_MAINTENANCE_TOKEN: token` for a particular request to bypass maintenance mode.
+
 ## Development
 
 See [How to contribute](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ Nevertheless passing option `[-c|--clear]` to command line above will reset prev
 
 - Enable/disable the plugin
 - Allow access for one or multiple ips addresses (optional)
-- Allow access for secret token (optional)
+- Allow access for secret token (session and request) (optional)
 - Create your custom message (optional)
 - Grant access to search bots during maintenance (optional)
+- Grant access to admins during maintenance (optional)
 
 ### If you want to put the **maintenance.yaml** in a directory, please add your directory in .env:
 

--- a/src/Checker/AdminChecker.php
+++ b/src/Checker/AdminChecker.php
@@ -40,14 +40,16 @@ class AdminChecker implements IsMaintenanceCheckerInterface
             $request = $this->requestStack->getMainRequest();
             Assert::isInstanceOf($request, Request::class);
 
-            if ($request === $this->requestStack->getCurrentRequest()) {
-                $flashBag = $request->getSession()->getBag('flashes');
-                if ($flashBag instanceof FlashBagInterface) {
-                    $flashBag->add('info', $this->translator->trans('maintenance.ui.message_info_admin'));
+            if ($configuration->isAllowAdmins()) {
+                if ($request === $this->requestStack->getCurrentRequest()) {
+                    $flashBag = $request->getSession()->getBag('flashes');
+                    if ($flashBag instanceof FlashBagInterface) {
+                        $flashBag->add('info', $this->translator->trans('maintenance.ui.message_info_admin'));
+                    }
                 }
-            }
 
-            return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+                return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+            }
         }
 
         return IsMaintenanceVoterInterface::ACCESS_DENIED;

--- a/src/Checker/TokenChecker.php
+++ b/src/Checker/TokenChecker.php
@@ -22,7 +22,9 @@ class TokenChecker implements IsMaintenanceCheckerInterface
     {
         if ($request->get('maintenanceToken') === $configuration->getToken()) {
             return IsMaintenanceVoterInterface::ACCESS_GRANTED;
-        } elseif ($request->getSession()->get(TokenStorage::MAINTENANCE_TOKEN_NAME) === $configuration->getToken()) {
+        }
+
+        if ($request->getSession()->get(TokenStorage::MAINTENANCE_TOKEN_NAME) === $configuration->getToken()) {
             return IsMaintenanceVoterInterface::ACCESS_GRANTED;
         }
 

--- a/src/Checker/TokenChecker.php
+++ b/src/Checker/TokenChecker.php
@@ -20,7 +20,11 @@ class TokenChecker implements IsMaintenanceCheckerInterface
 
     public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
     {
-        if ($request->request->get('maintenanceToken') === $configuration->getToken()) {
+        if ($request->query->get(TokenStorage::MAINTENANCE_TOKEN_NAME) === $configuration->getToken()) {
+            return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+        }
+
+        if ($request->headers->get(TokenStorage::MAINTENANCE_TOKEN_NAME) === $configuration->getToken()) {
             return IsMaintenanceVoterInterface::ACCESS_GRANTED;
         }
 

--- a/src/Checker/TokenChecker.php
+++ b/src/Checker/TokenChecker.php
@@ -20,7 +20,9 @@ class TokenChecker implements IsMaintenanceCheckerInterface
 
     public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
     {
-        if ($request->getSession()->get(TokenStorage::MAINTENANCE_TOKEN_NAME) === $configuration->getToken()) {
+        if ($request->get('maintenanceToken') === $configuration->getToken()) {
+            return IsMaintenanceVoterInterface::ACCESS_GRANTED;
+        } elseif ($request->getSession()->get(TokenStorage::MAINTENANCE_TOKEN_NAME) === $configuration->getToken()) {
             return IsMaintenanceVoterInterface::ACCESS_GRANTED;
         }
 

--- a/src/Checker/TokenChecker.php
+++ b/src/Checker/TokenChecker.php
@@ -20,7 +20,7 @@ class TokenChecker implements IsMaintenanceCheckerInterface
 
     public function isMaintenance(MaintenanceConfiguration $configuration, Request $request): bool
     {
-        if ($request->get('maintenanceToken') === $configuration->getToken()) {
+        if ($request->request->get('maintenanceToken') === $configuration->getToken()) {
             return IsMaintenanceVoterInterface::ACCESS_GRANTED;
         }
 

--- a/src/Command/EnableMaintenanceCommand.php
+++ b/src/Command/EnableMaintenanceCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -35,6 +36,7 @@ final class EnableMaintenanceCommand extends Command
     {
         $this
             ->addArgument('ips_address', InputArgument::IS_ARRAY, 'Add ips addresses (separate multiple ips with a space)')
+            ->addOption('disable-admin', null, InputOption::VALUE_NONE, 'disable admin access')
             ->setHelp('This command allows you to create the maintenance.yaml and also allows you to put the ips into this file.')
         ;
     }
@@ -67,6 +69,9 @@ final class EnableMaintenanceCommand extends Command
         $maintenanceConfiguration = $this->configurationFactory->get();
         $maintenanceConfiguration->setChannels($this->getChannels());
         $maintenanceConfiguration->setEnabled(true);
+
+        $disableAdmin = (bool) $input->getOption('disable-admin');
+        $maintenanceConfiguration->setAllowAdmins(!$disableAdmin);
 
         /** @var array $ipsAddress */
         $ipsAddress = $input->getArgument('ips_address');

--- a/src/Controller/MaintenanceConfigurationController.php
+++ b/src/Controller/MaintenanceConfigurationController.php
@@ -56,7 +56,8 @@ final class MaintenanceConfigurationController extends AbstractController
         }
 
         return $this->render('@SynoliaSyliusMaintenancePlugin/Admin/maintenanceConfiguration.html.twig', [
-            'form' => $form,
+            'maintenanceConfiguration' => $maintenanceConfiguration,
+            'form' => $form->createView(),
         ]);
     }
 }

--- a/src/EventSubscriber/MaintenanceEventsubscriber.php
+++ b/src/EventSubscriber/MaintenanceEventsubscriber.php
@@ -52,7 +52,7 @@ final readonly class MaintenanceEventsubscriber implements EventSubscriberInterf
             'custom_message' => $configuration->getCustomMessage(),
         ]);
 
-        if (str_contains($event->getRequest()->headers->get('Content-Type', ''), 'application/json')) {
+        if ('json' === $event->getRequest()->getContentTypeFormat()) {
             $event->setResponse(new JsonResponse([
                 'key' => 'maintenance',
                 'message' => $configuration->getCustomMessage(),

--- a/src/EventSubscriber/MaintenanceEventsubscriber.php
+++ b/src/EventSubscriber/MaintenanceEventsubscriber.php
@@ -6,6 +6,7 @@ namespace Synolia\SyliusMaintenancePlugin\EventSubscriber;
 
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -51,7 +52,17 @@ final readonly class MaintenanceEventsubscriber implements EventSubscriberInterf
             'custom_message' => $configuration->getCustomMessage(),
         ]);
 
-        $event->setResponse(new Response($responseContent, Response::HTTP_SERVICE_UNAVAILABLE));
+        if (!$event->getRequest()->isXmlHttpRequest()) {
+            $event->setResponse(new Response($responseContent, Response::HTTP_SERVICE_UNAVAILABLE));
+
+            return;
+        }
+
+        $response = [
+            'key' => 'maintenance',
+            'message' => $configuration->getCustomMessage(),
+        ];
+        $event->setResponse(new JsonResponse($response, Response::HTTP_SERVICE_UNAVAILABLE));
     }
 
     private function getMaintenanceConfiguration(): MaintenanceConfiguration

--- a/src/EventSubscriber/MaintenanceEventsubscriber.php
+++ b/src/EventSubscriber/MaintenanceEventsubscriber.php
@@ -52,17 +52,16 @@ final readonly class MaintenanceEventsubscriber implements EventSubscriberInterf
             'custom_message' => $configuration->getCustomMessage(),
         ]);
 
-        if (!$event->getRequest()->isXmlHttpRequest()) {
-            $event->setResponse(new Response($responseContent, Response::HTTP_SERVICE_UNAVAILABLE));
+        if (str_contains($event->getRequest()->headers->get('Content-Type', ''), 'application/json')) {
+            $event->setResponse(new JsonResponse([
+                'key' => 'maintenance',
+                'message' => $configuration->getCustomMessage(),
+            ], Response::HTTP_SERVICE_UNAVAILABLE));
 
             return;
         }
 
-        $response = [
-            'key' => 'maintenance',
-            'message' => $configuration->getCustomMessage(),
-        ];
-        $event->setResponse(new JsonResponse($response, Response::HTTP_SERVICE_UNAVAILABLE));
+        $event->setResponse(new Response($responseContent, Response::HTTP_SERVICE_UNAVAILABLE));
     }
 
     private function getMaintenanceConfiguration(): MaintenanceConfiguration

--- a/src/Exporter/MaintenanceConfigurationExporter.php
+++ b/src/Exporter/MaintenanceConfigurationExporter.php
@@ -38,6 +38,7 @@ final readonly class MaintenanceConfigurationExporter
         }
         $dataToExport['enabled'] = $configuration->isEnabled();
         $scheduler = $this->getSchedulerArray($configuration->getStartDate(), $configuration->getEndDate());
+        $dataToExport['allow_admins'] = $configuration->isAllowAdmins();
 
         $this->configurationFileManager->createMaintenanceFile(array_merge(
             $scheduler,

--- a/src/Factory/MaintenanceConfigurationFactory.php
+++ b/src/Factory/MaintenanceConfigurationFactory.php
@@ -46,7 +46,7 @@ final readonly class MaintenanceConfigurationFactory
             'custom_message' => '',
             'token' => '',
             'allow_bots' => false,
-            'allow_admins' => false,
+            'allow_admins' => true,
             'enabled' => true,
         ]);
         /**

--- a/src/Factory/MaintenanceConfigurationFactory.php
+++ b/src/Factory/MaintenanceConfigurationFactory.php
@@ -46,6 +46,7 @@ final readonly class MaintenanceConfigurationFactory
             'custom_message' => '',
             'token' => '',
             'allow_bots' => false,
+            'allow_admins' => false,
             'enabled' => true,
         ]);
         /**
@@ -79,6 +80,7 @@ final readonly class MaintenanceConfigurationFactory
             ->setCustomMessage($options['custom_message'])
             ->setToken($options['token'])
             ->setAllowBots($options['allow_bots'])
+            ->setAllowAdmins($options['allow_admins'])
             ->setEnabled($options['enabled'])
         ;
     }

--- a/src/Factory/MaintenanceConfigurationFactory.php
+++ b/src/Factory/MaintenanceConfigurationFactory.php
@@ -57,6 +57,7 @@ final readonly class MaintenanceConfigurationFactory
          *     'custom_message': string,
          *     'token': string,
          *     'allow_bots': bool,
+         *     'allow_admins': bool,
          *     'enabled': bool,
          *  } $options
          */

--- a/src/Form/Type/MaintenanceConfigurationType.php
+++ b/src/Form/Type/MaintenanceConfigurationType.php
@@ -67,6 +67,10 @@ final class MaintenanceConfigurationType extends AbstractType
                 'label' => 'maintenance.ui.form.allow_bots',
                 'required' => true,
             ])
+            ->add('allowAdmins', CheckboxType::class, [
+                'label' => 'maintenance.ui.form.allow_admins',
+                'required' => true,
+            ])
         ;
 
         if ($this->channelRepository->count([]) > 1) {

--- a/src/Model/MaintenanceConfiguration.php
+++ b/src/Model/MaintenanceConfiguration.php
@@ -24,7 +24,7 @@ class MaintenanceConfiguration
 
     private bool $allowBots = false;
 
-    private bool $allowAdmins = false;
+    private bool $allowAdmins = true;
 
     public function __construct()
     {

--- a/src/Model/MaintenanceConfiguration.php
+++ b/src/Model/MaintenanceConfiguration.php
@@ -24,6 +24,8 @@ class MaintenanceConfiguration
 
     private bool $allowBots = false;
 
+    private bool $allowAdmins = false;
+
     public function __construct()
     {
         $this->token = bin2hex(random_bytes(16));
@@ -155,6 +157,18 @@ class MaintenanceConfiguration
     public function setAllowBots(bool $allowBots): self
     {
         $this->allowBots = $allowBots;
+
+        return $this;
+    }
+
+    public function isAllowAdmins(): bool
+    {
+        return $this->allowAdmins;
+    }
+
+    public function setAllowAdmins(bool $allowAdmins): self
+    {
+        $this->allowAdmins = $allowAdmins;
 
         return $this;
     }

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,6 +1,6 @@
 maintenance:
     ui:
-        message: Die Webseite befindet im Wartungsmodus
+        message: Die Webseite befindet sich im Wartungsmodus
         title: Wartungsmodus
         subtitle: Wartungsmodus verwalten
         form:

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,0 +1,33 @@
+maintenance:
+    ui:
+        message: Die Webseite befindet im Wartungsmodus
+        title: Wartungsmodus
+        subtitle: Wartungsmodus verwalten
+        form:
+            enabled: Aktiv?
+            ip: Ip Adressen ignorieren (getrennt mit ,)
+            token_storage:
+                button: Generiere Token
+                help: Zugriff über Token erlauben
+                message: Token wurde generiert
+            placeholder: 'Ip Adressen ignorieren (getrennt mit ,) Zum Beispiel: 255.255.255.255,192.0.0.255'
+            custom_message: Nachricht
+            start_date: Start
+            end_date: Ende
+            error_end_date: End-Datum muss hinter Startdatum liegen
+            allow_bots: Erlaube Bots den Zugriff während dem Wartungsmodus
+            allow_admins: Erlaube Admins den Zugriff während dem Wartungsmodus
+        message_enabled: Wartungsmodus aktiviert
+        message_disabled: Wartungsmodus deaktiviert
+        message_reset: Wartungsmodus zurückgesetzt
+        message_success_ips: Ip Adressen wurden gespeichert
+        message_error_ips: Fehler in den Ip-Adressen
+        message_disabled_404: Das Plugin ist nicht aktiv
+        message_success_message: Nachricht erfolgreich gespeichert
+        message_end_date_in_the_past: End-Datum ist in der Vergangenheit, Wartungsmodus wurde beendet
+        message_info_admin: Die Webseite ist im Wartungsmodus
+sylius_plus:
+    rbac:
+        parent:
+            plugin_synolia_maintenances: Wartungsmodus
+        sylius_admin_maintenance_configuration: Wartungsmodus verwalten

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -16,6 +16,7 @@ maintenance:
             end_date: Ends at
             error_end_date: The end date must be later than the start date.
             allow_bots: Grant access to search bots during maintenance
+            allow_admins: Allow admins access during maintenance mode
         message_enabled: The maintenance plugin was successfully enabled.
         message_disabled: The maintenance plugin was successfully disabled.
         message_reset: The maintenance plugin was successfully reset.

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -16,6 +16,7 @@ maintenance:
             end_date: Se termine le
             error_end_date: La date de fin doit être postérieure à la date de début.
             allow_bots: Accorder l'accès aux robots de recherche pendant la maintenance
+            allow_admins: Autoriser l'accès aux administrateurs pendant le mode de maintenance
         message_enabled: Le plugin de maintenance a été activé avec succès.
         message_disabled: Le plugin de maintenance a été désactivé avec succès.
         message_reset: Le plugin de maintenance a été réinitialisé avec succès.

--- a/src/Resources/views/Admin/maintenanceConfiguration.html.twig
+++ b/src/Resources/views/Admin/maintenanceConfiguration.html.twig
@@ -37,6 +37,9 @@
 			<div class="field">
 				<div style="margin-bottom: 0.5em">{{ 'maintenance.ui.form.token_storage.help'|trans }}</div>
 				<a class="ui secondary button" href="{{ path('sylius_admin_maintenance_token_storage') }}">{{ 'maintenance.ui.form.token_storage.button'|trans }}</a>
+                {% if maintenanceConfiguration.token is defined %}
+                    {{ maintenanceConfiguration.token }}
+                {% endif %}
 			</div>
 		</div>
 		{{ form_row(form.customMessage) }}
@@ -45,6 +48,7 @@
 			{{ form_row(form.endDate) }}
 		</div>
 		{{ form_row(form.allowBots) }}
+		{{ form_row(form.allowAdmins) }}
 		{% include '@SyliusUi/Form/Buttons/_update.html.twig' %}
 		{{ form_end(form) }}
 	</div>

--- a/src/Resources/views/Admin/maintenanceConfiguration.html.twig
+++ b/src/Resources/views/Admin/maintenanceConfiguration.html.twig
@@ -37,8 +37,8 @@
 			<div class="field">
 				<div style="margin-bottom: 0.5em">{{ 'maintenance.ui.form.token_storage.help'|trans }}</div>
 				<a class="ui secondary button" href="{{ path('sylius_admin_maintenance_token_storage') }}">{{ 'maintenance.ui.form.token_storage.button'|trans }}</a>
-                {% if maintenanceConfiguration.token is defined %}
-                    {{ maintenanceConfiguration.token }}
+                {% if maintenanceConfiguration.enabled and maintenanceConfiguration.token is defined and maintenanceConfiguration.token is not empty %}
+                    <kbd>{{ maintenanceConfiguration.token }}</kbd>
                 {% endif %}
 			</div>
 		</div>

--- a/tests/PHPUnit/MaintenanceAllowAccessByTokenTest.php
+++ b/tests/PHPUnit/MaintenanceAllowAccessByTokenTest.php
@@ -25,6 +25,8 @@ final class MaintenanceAllowAccessByTokenTest extends WebTestCase
         string $token,
         bool $isGenerated,
         bool $isInMaintenance,
+        array $params = [],
+        array $headers = [],
     ): void {
         /** @var ReflectionClassConstant $constant */
         $constant = (new ReflectionClass(ConfigurationFileManager::class))
@@ -41,10 +43,10 @@ final class MaintenanceAllowAccessByTokenTest extends WebTestCase
 
         $client = static::createClient();
         if ($isGenerated) {
-            $session = $this->createSession($client, $token);
+            $this->createSession($client, $token);
         }
 
-        $client->request('GET', '/en_US/');
+        $client->request('GET', '/en_US/', $params, [], $headers);
 
         if ($isInMaintenance) {
             $this->assertSiteIsInMaintenance();
@@ -64,6 +66,18 @@ final class MaintenanceAllowAccessByTokenTest extends WebTestCase
         ];
         yield 'token generated is not that of the maintenance file, so no access to website' => [
             '63454fe526b4102103f76a4dbbd442e3', 'token123', true, true,
+        ];
+        yield 'token is not generated but queryParams are matching, so access allowed' => [
+            'g00d_s$cr3t', '', false, false, ['synolia_maintenance_token' => 'g00d_s$cr3t'],
+        ];
+        yield 'token is not generated but headers are matching, so access allowed' => [
+            'g00d_s$cr3t', '', false, false, [], ['HTTP_SYNOLIA_MAINTENANCE_TOKEN' => 'g00d_s$cr3t'],
+        ];
+        yield 'token is not generated but queryParams are not matching, so no access to website' => [
+            'g00d_s$cr3t', '', false, true, ['synolia_maintenance_token' => '0th4r_s$cr3t'],
+        ];
+        yield 'token is generated and same token, so access to website even if queryParams are not matching' => [
+            'g00d_s$cr3t', 'g00d_s$cr3t', true, false, ['synolia_maintenance_token' => '0th4r_s$cr3t'],
         ];
     }
 

--- a/tests/PHPUnit/MaintenanceAllowAccessToAdminAreaTest.php
+++ b/tests/PHPUnit/MaintenanceAllowAccessToAdminAreaTest.php
@@ -25,6 +25,7 @@ final class MaintenanceAllowAccessToAdminAreaTest extends AbstractWebTestCase
             $file,
             Yaml::dump([
                 'custom_message' => 'Maintenance ON',
+                'allow_admins' => false,
             ]),
         );
 
@@ -45,7 +46,6 @@ final class MaintenanceAllowAccessToAdminAreaTest extends AbstractWebTestCase
             $file,
             Yaml::dump([
                 'custom_message' => 'Maintenance ON',
-                'allow_admins' => true,
             ]),
         );
 

--- a/tests/PHPUnit/MaintenanceAllowAccessToAdminAreaTest.php
+++ b/tests/PHPUnit/MaintenanceAllowAccessToAdminAreaTest.php
@@ -13,6 +13,26 @@ final class MaintenanceAllowAccessToAdminAreaTest extends AbstractWebTestCase
 {
     use AssertTrait;
 
+    public function testMaintenanceDisallowAccessToAdminArea(): void
+    {
+        /** @var ReflectionClassConstant $constant */
+        $constant = (new ReflectionClass(ConfigurationFileManager::class))
+            ->getReflectionConstant('MAINTENANCE_FILE')
+        ;
+        $file = $constant->getValue();
+
+        \file_put_contents(
+            $file,
+            Yaml::dump([
+                'custom_message' => 'Maintenance ON',
+            ]),
+        );
+
+        self::$client->request('GET', '/admin/login');
+
+        self::assertResponseStatusCodeSame(503);
+    }
+
     public function testMaintenanceAllowAccessToAdminArea(): void
     {
         /** @var ReflectionClassConstant $constant */
@@ -25,6 +45,7 @@ final class MaintenanceAllowAccessToAdminAreaTest extends AbstractWebTestCase
             $file,
             Yaml::dump([
                 'custom_message' => 'Maintenance ON',
+                'allow_admins' => true,
             ]),
         );
 

--- a/tests/PHPUnit/MaintenanceEnabledTest.php
+++ b/tests/PHPUnit/MaintenanceEnabledTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnit;
+
+use Symfony\Component\Yaml\Yaml;
+use Tests\Synolia\SyliusMaintenancePlugin\PHPUnit\AbstractWebTestCase;
+
+final class MaintenanceEnabledTest extends AbstractWebTestCase
+{
+    public function testMaintenanceIsEnabledForJsonRequests(): void
+    {
+        \file_put_contents(
+            $this->file,
+            Yaml::dump([
+                'enabled' => true,
+                'custom_message' => 'niwebnimaster',
+            ]),
+        );
+        self::$client->jsonRequest('GET', '/en_US/');
+
+        self::assertResponseStatusCodeSame(503);
+        self::assertResponseFormatSame('json');
+        self::assertResponseHeaderSame('Content-Type', 'application/json');
+        self::assertIsArray(json_decode(self::$client->getResponse()->getContent(), true));
+        self::assertArrayHasKey('key', json_decode(self::$client->getResponse()->getContent(), true));
+        self::assertArrayHasKey('message', json_decode(self::$client->getResponse()->getContent(), true));
+        self::assertSame('maintenance', json_decode(self::$client->getResponse()->getContent(), true)['key']);
+        self::assertSame('niwebnimaster', json_decode(self::$client->getResponse()->getContent(), true)['message']);
+    }
+}


### PR DESCRIPTION
I added some improvements:

Grant access to admins during maintenance (optional) default false, so whole admin can be disabled
Allow access by secret token also on request
added german translations
added json response for json requests


@oallain as discussed in the closed pull request https://github.com/synolia/SyliusMaintenancePlugin/pull/39, i created a new one, based on the new 1.x branch. Please let me know, if this fits. Thank for your help.