### PR TITLE
fix: fails when fallback_url is missing

### DIFF
--- a/templates/admin/maintenance/content/header/title_block/actions/cancel.html.twig
+++ b/templates/admin/maintenance/content/header/title_block/actions/cancel.html.twig
@@ -1,5 +1,6 @@
 {% import '@SyliusAdmin/shared/helper/button.html.twig' as button %}
 
 {% set index_url = sylius_generate_redirect_path(app.request.headers.get('referer')) %}
+{% set fallback_url = path('sylius_admin_dashboard') %}
 
-{{ button.cancel(sylius_test_form_attribute('cancel-changes-button')|merge({ text: 'sylius.ui.cancel'|trans, url: index_url, class: 'btn' })) }}
+{{ button.cancel(sylius_test_form_attribute('cancel-changes-button')|merge({ text: 'sylius.ui.cancel'|trans, url: index_url, class: 'btn', fallback_url: fallback_url })) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed issue | #... <!-- #-prefixed issue number(s), if any -->

Sylius cancel button macro fails when fallback_url is not defined
